### PR TITLE
Use an updated version of papaparse

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ml-floyd-warshall": "^1.0.0",
     "ml-matrix": "^6.4.1",
     "openchemlib": "^7.2.3",
-    "papaparse": "^5.1.1",
+    "papaparse": "^5.3.0",
     "rxn-parser": "0.1.0",
     "sdf-parser": "^4.0.1"
   }


### PR DESCRIPTION
As reporded in https://www.npmjs.com/advisories/1515 :
"Versions of papaparse prior to 5.2.0 are vulnerable to Regular Expression Denial of Service (ReDos)".